### PR TITLE
feat(security): Command Source Validation

### DIFF
--- a/internal/github/config.go
+++ b/internal/github/config.go
@@ -9,10 +9,16 @@ import (
 
 // Config is the top-level GitHub agent configuration.
 type Config struct {
-	NATS    NATSConfig    `mapstructure:"nats"`
-	GitHub  GitHubConfig  `mapstructure:"github"`
-	Webhook WebhookConfig `mapstructure:"webhook"`
-	Poll    PollConfig    `mapstructure:"poll"`
+	NATS     NATSConfig     `mapstructure:"nats"`
+	GitHub   GitHubConfig   `mapstructure:"github"`
+	Webhook  WebhookConfig  `mapstructure:"webhook"`
+	Poll     PollConfig     `mapstructure:"poll"`
+	Security SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // NATSConfig holds NATS connection settings.
@@ -73,6 +79,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("webhook.secret", "GITHUB_WEBHOOK_SECRET")
 	v.BindEnv("nats.url", "SEKIA_NATS_URL")
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	// Config file is optional.
 	_ = v.ReadInConfig()

--- a/internal/gmail/agent.go
+++ b/internal/gmail/agent.go
@@ -154,14 +154,19 @@ func (ga *GmailAgent) publishEvent(ev protocol.Event) {
 }
 
 func (ga *GmailAgent) handleCommand(msg *nats.Msg) {
-	var cmd struct {
-		Command string         `json:"command"`
-		Payload map[string]any `json:"payload"`
-		Source  string         `json:"source"`
-	}
+	var cmd protocol.Command
 	if err := json.Unmarshal(msg.Data, &cmd); err != nil {
 		ga.agent.RecordError()
 		ga.logger.Error().Err(err).Msg("unmarshal command")
+		return
+	}
+
+	if !protocol.VerifyCommand(&cmd, ga.cfg.Security.CommandSecret) {
+		ga.agent.RecordError()
+		ga.logger.Warn().
+			Str("command", cmd.Command).
+			Str("source", cmd.Source).
+			Msg("rejected command: invalid or missing signature")
 		return
 	}
 

--- a/internal/gmail/config.go
+++ b/internal/gmail/config.go
@@ -9,10 +9,16 @@ import (
 
 // Config holds all configuration for the Gmail agent.
 type Config struct {
-	NATS NATSConfig `mapstructure:"nats"`
-	IMAP IMAPConfig `mapstructure:"imap"`
-	SMTP SMTPConfig `mapstructure:"smtp"`
-	Poll PollConfig `mapstructure:"poll"`
+	NATS     NATSConfig     `mapstructure:"nats"`
+	IMAP     IMAPConfig     `mapstructure:"imap"`
+	SMTP     SMTPConfig     `mapstructure:"smtp"`
+	Poll     PollConfig     `mapstructure:"poll"`
+	Security SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // NATSConfig holds NATS connection settings.
@@ -68,6 +74,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("smtp.password", "GMAIL_APP_PASSWORD")
 	v.BindEnv("nats.url", "SEKIA_NATS_URL")
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	_ = v.ReadInConfig() // config file is optional
 

--- a/internal/linear/config.go
+++ b/internal/linear/config.go
@@ -9,9 +9,15 @@ import (
 
 // Config holds all configuration for the Linear agent.
 type Config struct {
-	NATS   NATSConfig   `mapstructure:"nats"`
-	Linear LinearConfig `mapstructure:"linear"`
-	Poll   PollConfig   `mapstructure:"poll"`
+	NATS     NATSConfig     `mapstructure:"nats"`
+	Linear   LinearConfig   `mapstructure:"linear"`
+	Poll     PollConfig     `mapstructure:"poll"`
+	Security SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // NATSConfig holds NATS connection settings.
@@ -53,6 +59,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("linear.api_key", "LINEAR_API_KEY")
 	v.BindEnv("nats.url", "SEKIA_NATS_URL")
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	_ = v.ReadInConfig() // config file is optional
 

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -6,8 +6,14 @@ import (
 
 // Config holds all configuration for the MCP server.
 type Config struct {
-	NATS   NATSConfig   `mapstructure:"nats"`
-	Daemon DaemonConfig `mapstructure:"daemon"`
+	NATS     NATSConfig     `mapstructure:"nats"`
+	Daemon   DaemonConfig   `mapstructure:"daemon"`
+	Security SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // NATSConfig holds NATS connection settings.
@@ -42,6 +48,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("nats.url", "SEKIA_NATS_URL")
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
 	v.BindEnv("daemon.socket", "SEKIA_DAEMON_SOCKET")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	_ = v.ReadInConfig() // config file is optional
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -13,9 +13,10 @@ import (
 
 // MCPServer exposes sekia capabilities to AI assistants via MCP.
 type MCPServer struct {
-	api    DaemonAPI
-	nc     *nats.Conn
-	logger zerolog.Logger
+	api           DaemonAPI
+	nc            *nats.Conn
+	logger        zerolog.Logger
+	commandSecret string
 
 	// Overridable for testing.
 	natsOpts []nats.Option
@@ -24,8 +25,9 @@ type MCPServer struct {
 // New creates an MCPServer. Call Run() to start serving on stdio.
 func New(cfg Config, logger zerolog.Logger) *MCPServer {
 	s := &MCPServer{
-		api:    NewAPIClient(cfg.Daemon.Socket),
-		logger: logger.With().Str("component", "mcp").Logger(),
+		api:           NewAPIClient(cfg.Daemon.Socket),
+		logger:        logger.With().Str("component", "mcp").Logger(),
+		commandSecret: cfg.Security.CommandSecret,
 	}
 	if cfg.NATS.Token != "" {
 		s.natsOpts = append(s.natsOpts, nats.Token(cfg.NATS.Token))

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -98,12 +98,15 @@ func (s *MCPServer) handleSendCommand(ctx context.Context, req mcplib.CallToolRe
 		return textError("missing required parameter: payload"), nil
 	}
 
-	cmdMsg := map[string]any{
-		"command": command,
-		"payload": payload,
-		"source":  "mcp",
+	cmd := &protocol.Command{
+		Command: command,
+		Payload: payload,
+		Source:  "mcp",
 	}
-	data, err := json.Marshal(cmdMsg)
+	if err := protocol.SignCommand(cmd, s.commandSecret); err != nil {
+		return textError("failed to sign command: " + err.Error()), nil
+	}
+	data, err := json.Marshal(cmd)
 	if err != nil {
 		return textError("failed to marshal command: " + err.Error()), nil
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -17,6 +17,12 @@ type Config struct {
 	Workflows WorkflowConfig `mapstructure:"workflows"`
 	Web       WebConfig      `mapstructure:"web"`
 	AI        ai.Config      `mapstructure:"ai"`
+	Security  SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // WebConfig holds web dashboard settings.
@@ -85,6 +91,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
 	v.BindEnv("web.username", "SEKIA_WEB_USERNAME")
 	v.BindEnv("web.password", "SEKIA_WEB_PASSWORD")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	// Config file is optional.
 	_ = v.ReadInConfig()

--- a/internal/server/daemon.go
+++ b/internal/server/daemon.go
@@ -93,8 +93,11 @@ func (d *Daemon) Run() error {
 	}
 
 	// 4. Start workflow engine.
+	if d.cfg.Security.CommandSecret == "" {
+		d.logger.Warn().Msg("no command signing secret configured; commands will not be authenticated. Set security.command_secret or SEKIA_COMMAND_SECRET")
+	}
 	if d.cfg.Workflows.Dir != "" {
-		eng := workflow.New(ns.Conn(), d.cfg.Workflows.Dir, llm, d.cfg.Workflows.HandlerTimeout, d.logger)
+		eng := workflow.New(ns.Conn(), d.cfg.Workflows.Dir, llm, d.cfg.Workflows.HandlerTimeout, d.cfg.Security.CommandSecret, d.logger)
 		if err := eng.Start(); err != nil {
 			reg.Close()
 			ns.Shutdown()

--- a/internal/slack/config.go
+++ b/internal/slack/config.go
@@ -8,8 +8,14 @@ import (
 
 // Config holds all configuration for the Slack agent.
 type Config struct {
-	NATS  NATSConfig  `mapstructure:"nats"`
-	Slack SlackConfig `mapstructure:"slack"`
+	NATS     NATSConfig     `mapstructure:"nats"`
+	Slack    SlackConfig    `mapstructure:"slack"`
+	Security SecurityConfig `mapstructure:"security"`
+}
+
+// SecurityConfig holds application-level security settings.
+type SecurityConfig struct {
+	CommandSecret string `mapstructure:"command_secret"`
 }
 
 // NATSConfig holds NATS connection settings.
@@ -45,6 +51,7 @@ func LoadConfig(cfgFile string) (Config, error) {
 	v.BindEnv("slack.app_token", "SLACK_APP_TOKEN")
 	v.BindEnv("nats.url", "SEKIA_NATS_URL")
 	v.BindEnv("nats.token", "SEKIA_NATS_TOKEN")
+	v.BindEnv("security.command_secret", "SEKIA_COMMAND_SECRET")
 
 	_ = v.ReadInConfig() // config file is optional
 

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -53,7 +53,7 @@ func setupTestWithAuth(t *testing.T, username, password string) (*Server, *nats.
 	}
 	t.Cleanup(reg.Close)
 
-	eng := workflow.New(nc, t.TempDir(), nil, 0, logger)
+	eng := workflow.New(nc, t.TempDir(), nil, 0, "", logger)
 	if err := eng.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -55,7 +55,7 @@ end)
 	wfPath := filepath.Join(tmpDir, "echo.lua")
 	os.WriteFile(wfPath, []byte(workflowCode), 0644)
 
-	eng := New(nc, tmpDir, nil, 0, testLogger())
+	eng := New(nc, tmpDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}
@@ -122,7 +122,7 @@ end)
 	wfPath := filepath.Join(tmpDir, "looper.lua")
 	os.WriteFile(wfPath, []byte(workflowCode), 0644)
 
-	eng := New(nc, tmpDir, nil, 0, testLogger())
+	eng := New(nc, tmpDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}
@@ -160,7 +160,7 @@ end)
 	wfPath := filepath.Join(tmpDir, "catchall.lua")
 	os.WriteFile(wfPath, []byte(workflowCode), 0644)
 
-	eng := New(nc, tmpDir, nil, 0, testLogger())
+	eng := New(nc, tmpDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}
@@ -217,7 +217,7 @@ end)
 	os.WriteFile(filepath.Join(tmpDir, "wf_a.lua"), []byte(wfA), 0644)
 	os.WriteFile(filepath.Join(tmpDir, "wf_b.lua"), []byte(wfB), 0644)
 
-	eng := New(nc, tmpDir, nil, 0, testLogger())
+	eng := New(nc, tmpDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}
@@ -277,7 +277,7 @@ end)
 	wfPath := filepath.Join(tmpDir, "erroring.lua")
 	os.WriteFile(wfPath, []byte(workflowCode), 0644)
 
-	eng := New(nc, tmpDir, nil, 0, testLogger())
+	eng := New(nc, tmpDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}
@@ -317,7 +317,7 @@ end)
 	os.WriteFile(wfPath, []byte(workflowCode), 0644)
 
 	// Use a short timeout (200ms) so the test doesn't hang.
-	eng := New(nc, tmpDir, nil, 200*time.Millisecond, testLogger())
+	eng := New(nc, tmpDir, nil, 200*time.Millisecond, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("engine start: %v", err)
 	}

--- a/internal/workflow/loader_test.go
+++ b/internal/workflow/loader_test.go
@@ -23,7 +23,7 @@ func TestLoadDir(t *testing.T) {
 	`), 0644)
 	os.WriteFile(filepath.Join(wfDir, "readme.txt"), []byte("not a workflow"), 0644)
 
-	eng := New(nc, wfDir, nil, 0, testLogger())
+	eng := New(nc, wfDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestLoadDir_EmptyDir(t *testing.T) {
 	wfDir := filepath.Join(tmpDir, "workflows")
 	// Don't create it — LoadDir should create it.
 
-	eng := New(nc, wfDir, nil, 0, testLogger())
+	eng := New(nc, wfDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestLoadDir_SyntaxError(t *testing.T) {
 		this is not valid lua !@#$
 	`), 0644)
 
-	eng := New(nc, wfDir, nil, 0, testLogger())
+	eng := New(nc, wfDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestReloadAll(t *testing.T) {
 		sekia.on("sekia.events.v1", function(event) end)
 	`), 0644)
 
-	eng := New(nc, wfDir, nil, 0, testLogger())
+	eng := New(nc, wfDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestHotReload(t *testing.T) {
 	wfDir := filepath.Join(tmpDir, "workflows")
 	os.MkdirAll(wfDir, 0755)
 
-	eng := New(nc, wfDir, nil, 0, testLogger())
+	eng := New(nc, wfDir, nil, 0, "", testLogger())
 	if err := eng.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/pkg/protocol/command.go
+++ b/pkg/protocol/command.go
@@ -1,0 +1,9 @@
+package protocol
+
+// Command is the canonical command envelope published on sekia.commands.<agent>.
+type Command struct {
+	Command   string         `json:"command"`
+	Payload   map[string]any `json:"payload"`
+	Source    string         `json:"source"`
+	Signature string         `json:"signature,omitempty"`
+}

--- a/pkg/protocol/signing.go
+++ b/pkg/protocol/signing.go
@@ -1,0 +1,60 @@
+package protocol
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
+
+// signingPayload is the subset of Command fields that are signed.
+// A dedicated struct ensures deterministic JSON marshal order.
+type signingPayload struct {
+	Command string         `json:"command"`
+	Payload map[string]any `json:"payload"`
+	Source  string         `json:"source"`
+}
+
+// SignCommand computes an HMAC-SHA256 signature for the command and sets cmd.Signature.
+// If secret is empty, the command is left unsigned.
+func SignCommand(cmd *Command, secret string) error {
+	if secret == "" {
+		return nil
+	}
+	canonical, err := json.Marshal(signingPayload{
+		Command: cmd.Command,
+		Payload: cmd.Payload,
+		Source:  cmd.Source,
+	})
+	if err != nil {
+		return err
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(canonical)
+	cmd.Signature = hex.EncodeToString(mac.Sum(nil))
+	return nil
+}
+
+// VerifyCommand checks the HMAC-SHA256 signature on a command.
+// If secret is empty, verification is skipped (returns true).
+// If the command has no signature but a secret is configured, returns false.
+func VerifyCommand(cmd *Command, secret string) bool {
+	if secret == "" {
+		return true
+	}
+	if cmd.Signature == "" {
+		return false
+	}
+	canonical, err := json.Marshal(signingPayload{
+		Command: cmd.Command,
+		Payload: cmd.Payload,
+		Source:  cmd.Source,
+	})
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(canonical)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(cmd.Signature))
+}

--- a/pkg/protocol/signing_test.go
+++ b/pkg/protocol/signing_test.go
@@ -1,0 +1,162 @@
+package protocol
+
+import (
+	"testing"
+)
+
+func TestSignAndVerify(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"owner": "acme", "repo": "app", "number": float64(42), "label": "bug"},
+		Source:  "workflow:auto-labeler",
+	}
+	secret := "test-secret-key"
+
+	if err := SignCommand(cmd, secret); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+	if cmd.Signature == "" {
+		t.Fatal("expected non-empty signature")
+	}
+	if !VerifyCommand(cmd, secret) {
+		t.Fatal("VerifyCommand returned false for valid signature")
+	}
+}
+
+func TestVerifyTamperedPayload(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:test",
+	}
+	secret := "my-secret"
+
+	if err := SignCommand(cmd, secret); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+
+	cmd.Payload["label"] = "critical"
+
+	if VerifyCommand(cmd, secret) {
+		t.Fatal("VerifyCommand returned true for tampered payload")
+	}
+}
+
+func TestVerifyTamperedCommand(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:test",
+	}
+	secret := "my-secret"
+
+	if err := SignCommand(cmd, secret); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+
+	cmd.Command = "close_issue"
+
+	if VerifyCommand(cmd, secret) {
+		t.Fatal("VerifyCommand returned true for tampered command name")
+	}
+}
+
+func TestVerifyTamperedSource(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:legit",
+	}
+	secret := "my-secret"
+
+	if err := SignCommand(cmd, secret); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+
+	cmd.Source = "workflow:evil"
+
+	if VerifyCommand(cmd, secret) {
+		t.Fatal("VerifyCommand returned true for tampered source")
+	}
+}
+
+func TestVerifyWrongSecret(t *testing.T) {
+	cmd := &Command{
+		Command: "send_message",
+		Payload: map[string]any{"channel": "general"},
+		Source:  "mcp",
+	}
+
+	if err := SignCommand(cmd, "secret-a"); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+
+	if VerifyCommand(cmd, "secret-b") {
+		t.Fatal("VerifyCommand returned true for wrong secret")
+	}
+}
+
+func TestEmptySecretSkipsSigning(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:test",
+	}
+
+	if err := SignCommand(cmd, ""); err != nil {
+		t.Fatalf("SignCommand: %v", err)
+	}
+	if cmd.Signature != "" {
+		t.Fatalf("expected empty signature, got %q", cmd.Signature)
+	}
+}
+
+func TestEmptySecretSkipsVerification(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:test",
+	}
+
+	if !VerifyCommand(cmd, "") {
+		t.Fatal("VerifyCommand with empty secret should return true")
+	}
+}
+
+func TestSecretConfiguredNoSignature(t *testing.T) {
+	cmd := &Command{
+		Command: "add_label",
+		Payload: map[string]any{"label": "bug"},
+		Source:  "workflow:test",
+	}
+
+	if VerifyCommand(cmd, "my-secret") {
+		t.Fatal("VerifyCommand should return false when secret configured but no signature present")
+	}
+}
+
+func TestDeterministicSignature(t *testing.T) {
+	secret := "deterministic-test"
+
+	cmd1 := &Command{
+		Command: "create_comment",
+		Payload: map[string]any{"body": "hello", "number": float64(1)},
+		Source:  "workflow:reviewer",
+	}
+	cmd2 := &Command{
+		Command: "create_comment",
+		Payload: map[string]any{"body": "hello", "number": float64(1)},
+		Source:  "workflow:reviewer",
+	}
+
+	if err := SignCommand(cmd1, secret); err != nil {
+		t.Fatalf("SignCommand cmd1: %v", err)
+	}
+	if err := SignCommand(cmd2, secret); err != nil {
+		t.Fatalf("SignCommand cmd2: %v", err)
+	}
+
+	if cmd1.Signature != cmd2.Signature {
+		t.Fatalf("signatures differ: %s vs %s", cmd1.Signature, cmd2.Signature)
+	}
+}


### PR DESCRIPTION
# HMAC-SHA256 Command Signing & Verification

## Context

Currently, agents deserialize and execute commands from NATS without checking who sent them. The source field is logged but never validated. Any NATS client can publish to sekia.commands.* and agents will blindly execute. This adds a shared-secret HMAC-SHA256 signature to all command messages, verified by agents before execution.

## Approach

- Add a formal `protocol.Command` struct (currently commands are ad-hoc `map[string]any`)
- Add `SignCommand()`/`VerifyCommand()` functions in `pkg/protocol/`
- Sign commands at the 2 publish points (workflow engine, MCP server)
- Verify commands at all 4 agent consume points
- Config: `[security] command_secret` in each TOML file, env var `SEKIA_COMMAND_SECRET`
- Backward compatible: empty secret = no signing/verification (with warning log)
